### PR TITLE
Upgrade CoreNLP to 3.9.2 for newer Java versions compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
     <dependency>
       <groupId>edu.stanford.nlp</groupId>
       <artifactId>stanford-corenlp</artifactId>
-      <version>3.4.1</version>
+      <version>3.9.2</version>
     </dependency>
 
     <dependency>
       <groupId>edu.stanford.nlp</groupId>
       <artifactId>stanford-corenlp</artifactId>
-      <version>3.4.1</version>
+      <version>3.9.2</version>
       <classifier>models</classifier>
     </dependency>
 

--- a/src/main/java/ims/cs/corenlp/TokenAligner.java
+++ b/src/main/java/ims/cs/corenlp/TokenAligner.java
@@ -266,7 +266,7 @@ public class TokenAligner {
 
 		// for compatibility: TreeGraphNode bookkeeping
 		Collection<TypedDependency> dependencyEdges = dependencies.typedDependencies();
-		List<TreeGraphNode> tgnList = new ArrayList<TreeGraphNode>(cTokens.size());
+		List<IndexedWord> tgnList = new ArrayList<>(cTokens.size());
 
 		for (int i = 0; i < cTokens.size()+1; i++)
 			tgnList.add(null);
@@ -277,12 +277,12 @@ public class TokenAligner {
 			tgnList.set(edge.dep().index(), edge.dep());
 		}
 
-		Iterator<TreeGraphNode> tgnIterator = tgnList.iterator();
+		Iterator<IndexedWord> tgnIterator = tgnList.iterator();
 
 
 		IndexedWord dep = null;
 		Tree leaf = null;
-		TreeGraphNode tgn = null;
+		IndexedWord tgn = null;
 
 
 

--- a/src/main/java/ims/cs/lingdata/Token.java
+++ b/src/main/java/ims/cs/lingdata/Token.java
@@ -86,7 +86,7 @@ public class Token {
 	// CoreNlp compatibility
 	public IndexedWord dependencyBackpointer;
 	public Tree treeBackpointer;
-	public TreeGraphNode tgn;
+	public IndexedWord tgn;
 
 	// perceptron stuff
 	public double perceptronBeginScore;

--- a/src/main/java/ims/cs/util/StaticConfig.java
+++ b/src/main/java/ims/cs/util/StaticConfig.java
@@ -17,10 +17,7 @@
 
 package ims.cs.util;
 
-import sun.applet.Main;
-
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;


### PR DESCRIPTION
I’m currently using both Java 8 and Java 11 on my machine (Oracle and OpenJDK). Given the core packages restructuring that came with Java 9, some of the code is not working anymore on the newer versions.

An example is the unused import in `StaticConfig`, specifically line 20 `import sun.applet.Main;
`.

Other compatibility issues can be fixed by upgrading CoreNLP to version **3.9.2**. See more [here](https://github.com/stanfordnlp/CoreNLP/issues/636).